### PR TITLE
lazy로딩을 위한 이미지 컴포넌트 가져옴, 아이템 애니메이션 수정

### DIFF
--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,0 +1,100 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { ImgHTMLAttributes, useEffect, useRef, useState } from 'react';
+
+export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+  ref?: React.RefObject<HTMLImageElement>;
+  lazy?: boolean;
+  threshold?: number;
+  src?: string;
+  placeholder?: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  block?: boolean;
+  mode?: 'contain' | 'cover' | 'none';
+  style?: React.CSSProperties;
+}
+
+let observer: IntersectionObserver | null = null;
+
+// CUSTOM EVENT TYPE
+const LOAD_IMG_EVENT_TYPE = 'loadImage';
+
+const onIntersection: IntersectionObserverCallback = (entries, observer) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      // IntersectionObserver가 인식한 이미지가 보여지는 영역에 들어왔을 때,
+      observer.unobserve(entry.target); // 기존 element observe를 해제한다.
+      entry.target.dispatchEvent(new CustomEvent(LOAD_IMG_EVENT_TYPE)); // 커스텀 이벤트를 호출한다.
+    }
+  });
+};
+
+export const Image = ({
+  lazy,
+  threshold = 0.3,
+  src,
+  placeholder = '',
+  alt,
+  width,
+  height,
+  mode,
+  block,
+  style,
+  ...props
+}: ImageProps) => {
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (!lazy) {
+      setIsLoaded(true);
+      return;
+    }
+    const handleLoadImage = () => setIsLoaded(true);
+    const imgElement = imgRef.current;
+
+    imgElement && imgElement.addEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage);
+    return () => {
+      imgElement && imgElement.removeEventListener(LOAD_IMG_EVENT_TYPE, handleLoadImage);
+    };
+  }, [lazy]);
+
+  useEffect(() => {
+    if (!lazy) {
+      return;
+    }
+    if (!observer) {
+      observer = new IntersectionObserver(onIntersection, { threshold });
+    }
+    imgRef.current && observer.observe(imgRef.current);
+  }, [lazy, threshold]);
+
+  return (
+    <ImageBase
+      ref={imgRef}
+      alt={alt}
+      src={isLoaded ? src : placeholder}
+      width={width}
+      height={height}
+      mode={mode}
+      block={block}
+      style={style}
+      {...props}
+    />
+  );
+};
+
+const ImageBase = styled('img')<ImageProps>`
+  ${props => {
+    const { width, height, mode, block } = props;
+    return css`
+      width: ${width ? `${width}px` : '100%'};
+      height: ${height ? `${height}px` : '100%'};
+      object-fit: ${mode ?? 'fill'};
+      display: ${block ? 'block' : 'inline-block'};
+    `;
+  }}
+  vertical-align: top;
+`;

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -22,13 +22,13 @@ let observer: IntersectionObserver | null = null;
 const LOAD_IMG_EVENT_TYPE = 'loadImage';
 
 const onIntersection: IntersectionObserverCallback = (entries, observer) => {
-  entries.forEach(entry => {
-    if (entry.isIntersecting) {
+  entries
+    .filter(entry => entry.isIntersecting)
+    .forEach(entry => {
       // IntersectionObserver가 인식한 이미지가 보여지는 영역에 들어왔을 때,
       observer.unobserve(entry.target); // 기존 element observe를 해제한다.
       entry.target.dispatchEvent(new CustomEvent(LOAD_IMG_EVENT_TYPE)); // 커스텀 이벤트를 호출한다.
-    }
-  });
+    });
 };
 
 export const Image = ({

--- a/src/components/Item/index.tsx
+++ b/src/components/Item/index.tsx
@@ -30,7 +30,7 @@ const descVariant = {
     y: '50%',
     x: '-50%',
     transition: {
-      duration: 0.3,
+      duration: 0.2,
     },
   },
   leave: {
@@ -38,7 +38,7 @@ const descVariant = {
     y: 25,
     x: '-50%',
     transition: {
-      duration: 1,
+      duration: 0.2,
     },
   },
 };
@@ -67,15 +67,17 @@ export function Item({ imgUrl, like, title }: ItemProps) {
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} />
-        {hovered && (
-          <StyledDescription variants={descVariant} initial="entry" animate="animate" exit="leave">
-            <Image src="/icon/like.png" alt="Like Icon" width={25} height={25} />
-            <Text variant="title03" color="gray120">
-              {like}
-            </Text>
-          </StyledDescription>
-        )}
+        <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} mode="cover" threshold={0.9} />
+        <AnimatePresence mode="wait">
+          {hovered && (
+            <StyledDescription variants={descVariant} initial="entry" animate="animate" exit="leave">
+              <Image src="/icon/like.png" alt="Like Icon" width={25} height={25} />
+              <Text variant="title03" color="gray120">
+                {like}
+              </Text>
+            </StyledDescription>
+          )}
+        </AnimatePresence>
       </StyledItem>
     </AnimatePresence>
   );
@@ -101,7 +103,7 @@ const StyledDescription = styled(motion.div)`
 const StyledItem = styled(motion.li)`
   width: 30%;
   border-radius: 50%;
-  padding-bottom: 30%;
+  padding-bottom: 35%;
   margin: 20px 0;
   position: relative;
   overflow: hidden;

--- a/src/components/Item/index.tsx
+++ b/src/components/Item/index.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 
 import { theme } from '../../theme';
+import { Image as ItemImage } from '../Image';
 import { Text } from '../Text';
 
 const itemVariant = {
@@ -25,15 +26,15 @@ const itemVariant = {
   },
 };
 
-const imgVariant = {
-  hover: {
-    opacity: 0.1,
-    scale: 1.1,
-    transition: {
-      duration: 0.2,
-    },
-  },
-};
+// const imgVariant = {
+//   hover: {
+//     opacity: 0.1,
+//     scale: 1.1,
+//     transition: {
+//       duration: 0.2,
+//     },
+//   },
+// };
 
 const descVariant = {
   entry: {
@@ -82,7 +83,8 @@ export function Item({ imgUrl, like, title }: ItemProps) {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <StyledImage src={imgUrl} alt={title} variants={imgVariant} whileHover="hover" />
+      {/* <StyledImage src={imgUrl} alt={title} variants={imgVariant} whileHover="hover" /> */}
+      <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} />
       {hovered && (
         <StyledDescription variants={descVariant} initial="entry" animate="animate" exit="leave">
           <Image src="/icon/like.png" alt="Like Icon" width={25} height={25} />
@@ -95,7 +97,7 @@ export function Item({ imgUrl, like, title }: ItemProps) {
   );
 }
 
-const StyledImage = styled(motion.img)`
+const StyledImage = styled(ItemImage)`
   width: 100%;
   height: 100%;
   position: absolute;

--- a/src/components/Item/index.tsx
+++ b/src/components/Item/index.tsx
@@ -63,11 +63,12 @@ export function Item({ imgUrl, like, title }: ItemProps) {
       <StyledItem
         variants={itemVariant}
         initial="entry"
-        animate="animate"
+        whileInView="animate"
+        viewport={{ once: true }}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} mode="cover" threshold={0.9} />
+        <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} mode="cover" threshold={0.1} />
         <AnimatePresence mode="wait">
           {hovered && (
             <StyledDescription variants={descVariant} initial="entry" animate="animate" exit="leave">

--- a/src/components/Item/index.tsx
+++ b/src/components/Item/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { HTMLMotionProps, motion } from 'framer-motion';
+import { AnimatePresence, HTMLMotionProps, motion } from 'framer-motion';
 import Image from 'next/image';
 import { useState } from 'react';
 
@@ -9,32 +9,15 @@ import { Text } from '../Text';
 
 const itemVariant = {
   entry: {
-    borderRadius: '50%',
+    scale: 0.6,
   },
-  hover: {
-    borderRadius: '10%',
-    backgroundColor: theme.colors.primary_deep,
+  animate: {
+    scale: 1,
     transition: {
-      duration: 0.2,
-    },
-    descOpacity: {
-      opacity: 1,
-      transition: {
-        duration: 0.2,
-      },
+      duration: 0.4,
     },
   },
 };
-
-// const imgVariant = {
-//   hover: {
-//     opacity: 0.1,
-//     scale: 1.1,
-//     transition: {
-//       duration: 0.2,
-//     },
-//   },
-// };
 
 const descVariant = {
   entry: {
@@ -76,24 +59,25 @@ export function Item({ imgUrl, like, title }: ItemProps) {
     setHovered(false);
   };
   return (
-    <StyledItem
-      variants={itemVariant}
-      initial="entry"
-      whileHover="hover"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      {/* <StyledImage src={imgUrl} alt={title} variants={imgVariant} whileHover="hover" /> */}
-      <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} />
-      {hovered && (
-        <StyledDescription variants={descVariant} initial="entry" animate="animate" exit="leave">
-          <Image src="/icon/like.png" alt="Like Icon" width={25} height={25} />
-          <Text variant="title03" color="gray120">
-            {like}
-          </Text>
-        </StyledDescription>
-      )}
-    </StyledItem>
+    <AnimatePresence>
+      <StyledItem
+        variants={itemVariant}
+        initial="entry"
+        animate="animate"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <StyledImage lazy={true} src={imgUrl} alt={title} width={100} height={100} />
+        {hovered && (
+          <StyledDescription variants={descVariant} initial="entry" animate="animate" exit="leave">
+            <Image src="/icon/like.png" alt="Like Icon" width={25} height={25} />
+            <Text variant="title03" color="gray120">
+              {like}
+            </Text>
+          </StyledDescription>
+        )}
+      </StyledItem>
+    </AnimatePresence>
   );
 }
 
@@ -116,6 +100,7 @@ const StyledDescription = styled(motion.div)`
 
 const StyledItem = styled(motion.li)`
   width: 30%;
+  border-radius: 50%;
   padding-bottom: 30%;
   margin: 20px 0;
   position: relative;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './PageTransition';
 export * from './Item';
 export * from './ItemList';
 export * from './ThreeBackground';
+export * from './Image';

--- a/src/service/Home/index.tsx
+++ b/src/service/Home/index.tsx
@@ -38,7 +38,7 @@ function Home() {
     <PageTransition>
       <StyledLayout>
         <ItemList>
-          {[...mockItems, ...mockItems].map(({ imgUrl, like, title }, index) => (
+          {[...mockItems, ...mockItems, ...mockItems, ...mockItems].map(({ imgUrl, like, title }, index) => (
             <Item key={index} imgUrl={imgUrl} like={like} title={title} />
           ))}
         </ItemList>


### PR DESCRIPTION
- lazy로딩을 위해 Image컴포넌트 가져옴
- 아이템 등장 애니메이션을 로딩 상태를 통해서 구현해야하나 싶어서 삽질함
- 결과적으로는 부모가 로딩을 위한 상태를 갖고 자식에 공유해야하는데 자체적으로 부모에서 IntersectionObserver를 사용하는게 맞다고 깨달음
- Framer에서 이것을 위해 whileInView속성을 지원하는걸 알게됨, animate속성 대신에 이것을 사용함
- 추가로 글자가 사라지는 효과는 적용이 안됐었는데 AnimatePresence로 해결함